### PR TITLE
Many diagrams

### DIFF
--- a/lib/dash/counter.ex
+++ b/lib/dash/counter.ex
@@ -15,7 +15,9 @@ defmodule Dash.Counter do
 	updates every seconds
 	"""
 	def start_link() do
-		dict = HashDict.new |> Dict.put("first", set_value(0))
+		dict = HashDict.new 
+			|> Dict.put("first", set_value(0))
+			|> Dict.put("second", set_value(0))
 		res = Agent.start_link(fn -> dict end, 
 			name: __MODULE__)
 		timer = :timer.apply_interval(1_000, __MODULE__, :timed_update, [])

--- a/web/channels/counter_channel.ex
+++ b/web/channels/counter_channel.ex
@@ -8,7 +8,7 @@ defmodule Dash.CounterChannel do
   def join("counters:lobby", payload, socket) do
     Logger.info "joing counters:lobby from socket #{inspect socket}"
     if authorized?(payload) do
-      {:ok, Dash.Counter.get(@counter), socket}
+      {:ok, %{id: @counter, counter: Dash.Counter.get(@counter)}, socket}
     else
       {:error, %{reason: "unauthorized"}}
     end

--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -69,10 +69,6 @@ port sendValuePort =
 -- Get something from phoenix
 port getCounterValue : Signal CounterType
 
--- Send the current history to D3 time series
-port sendHistoryPort : Signal History
-port sendHistoryPort = sendHistoryMailBox.signal
-
 -- Output Ports => results in drawing graph of diagram_stream via JS 
 port data_graph_port : Signal Simple_Options
 port data_graph_port = diagram_stream_mailbox.signal

--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -10,6 +10,7 @@ import Html.Attributes exposing (class, id)
 import Html.Events exposing (onClick)
 
 import Dash.Diagram exposing (..)
+import Json.Encode exposing (Value)
 
 {-- 
   What to do here properly: 
@@ -71,7 +72,7 @@ port sendValuePort =
 port getCounterValue : Signal CounterType
 
 -- Output Ports => results in drawing graph of diagram_stream via JS 
-port data_graph_port : Signal Simple_Options
+port data_graph_port : Signal Json.Encode.Value
 port data_graph_port = diagram_stream_mailbox.signal
 
 -- SIGNALS

--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -4,6 +4,7 @@ import StartApp exposing (App)
 import Effects exposing (Effects, Never)
 import Task exposing (Task)
 import Time exposing (Time)
+import Dict exposing (Dict)
 
 import Html exposing (..)
 import Html.Attributes exposing (class, id)
@@ -16,7 +17,9 @@ import Json.Encode exposing (Value)
   What to do here properly: 
     * design a module for a time series chart, addressable, such 
       that incoming data can be sent to. ==> Data comes in from phoenix via sockets
-    * design a larger frame, where charts can be embedded
+      ==> DONE
+    * design a larger frame, where charts can be embedded. The model is a dictionary,
+      mapping ids (or targets) to the diagram model.
     * design an even larger frame with menu etc. 
   What not to do: 
     * Mess around with times etc in Elm since time is bound to signals.
@@ -30,7 +33,11 @@ init =
 
 
 -- MODEL
-type alias Model = Dash.Diagram.Model
+type alias Id = String 
+type alias Model = Dict.Dict Id Dash.Diagram.Model
+
+-- the counter update message as sent from Phoenix
+type alias CounterMsg = {id: Id, counter: CounterType}
 -- The counter holds the value and the current time stamp
 type alias CounterType = {date: Time, value: Int}
 type alias History = List CounterType
@@ -39,32 +46,47 @@ type alias History = List CounterType
 
 type Action 
   = NoOp 
-  | Reset 
-  | SubMessage Dash.Diagram.Action
+  | Reset Id
+  | SubMessage Id Dash.Diagram.Action
 
 update : Action -> Model -> (Model, Effects Action)
 update action model = 
     case action of
         NoOp -> (model, Effects.none) -- do nothing
-        Reset -> reset_single_diagram reset_model
-        SubMessage diag_act -> update_single_diagram diag_act model
+        Reset id -> reset_single_diagram id reset_model
+        SubMessage id diag_act -> update_single_diagram id diag_act model
           
-update_single_diagram : Dash.Diagram.Action -> Model -> (Model, Effects Action)
-update_single_diagram diag_act model = 
+update_single_diagram : Id -> Dash.Diagram.Action -> Model -> (Model, Effects Action)
+update_single_diagram id diag_act model = 
     let
-      (m, a) = Dash.Diagram.update (diag_act) model
+      diag = get_diagram id model 
+      (d, a) = Dash.Diagram.update (diag_act) diag
+      m = Dict.update id (\v -> Just d) model
     in
-      (m, Effects.map SubMessage a)
+      (m, Effects.map (SubMessage id) a)
 
-reset_single_diagram : Model -> (Model, Effects Action)
-reset_single_diagram model = 
+reset_single_diagram : Id -> Model -> (Model, Effects Action)
+reset_single_diagram id model = 
   let
-      (m, a) = Dash.Diagram.reset model
+      diag = get_diagram id model
+      (d, a) = Dash.Diagram.reset diag
+      m = Dict.update id (\v -> Just d) model
     in
-      (m, Effects.map SubMessage a)
+      (m, Effects.map (SubMessage id) a)
 
 reset_model : Model
-reset_model = Dash.Diagram.init_model "elmChart"
+reset_model = 
+  let id = "elmChart" 
+  in Dict.singleton id (Dash.Diagram.init_model id)
+
+-- expects that the key exists. there is no runtime error,
+-- but an empty diagram is returned, if the key is not in the model
+get_diagram: Id -> Model -> Dash.Diagram.Model
+get_diagram id model = 
+  let
+    emptyDiagram = Dash.Diagram.init_model "Unknown Identifier for Chart"
+  in 
+    Maybe.withDefault emptyDiagram (Dict.get id model)
 
 -- EFFECTS
 
@@ -76,7 +98,7 @@ port sendValuePort =
     sendValueMailBox.signal 
 
 -- Get something from phoenix
-port getCounterValue : Signal CounterType
+port getCounterValue : Signal CounterMsg
 
 -- Output Ports => results in drawing graph of diagram_stream via JS 
 port data_graph_port : Signal Json.Encode.Value
@@ -85,7 +107,8 @@ port data_graph_port = diagram_stream_mailbox.signal
 -- SIGNALS
 setCounterAction: Signal Action
 setCounterAction = 
-  Signal.map (\v -> SubMessage (Dash.Diagram.new_value v)) getCounterValue
+  Signal.map (\v -> 
+      SubMessage v.id (Dash.Diagram.new_value v.counter)) getCounterValue
 
 incomingActions : Signal Action
 incomingActions = setCounterAction
@@ -99,15 +122,22 @@ sendValueMailBox =
 view : Signal.Address Action -> Model -> Html.Html
 view address model =
  div []
-    [ h2 [] [(text "The Big Elm Chart - Single Chart variant")]
-    , (diagView address model)
-      ]
+    [ h2 [] [(text "The Big Elm Chart - List Chart variant")]
+    , div [] (all_diags address model)
+    ]
 
-diagView : Signal.Address Action -> Model -> Html.Html
-diagView address model = 
+all_diags : Signal.Address Action ->Model -> List Html.Html
+all_diags address model = 
+  Dict.toList model 
+    |> List.map (\entry -> 
+      let (id, v) = entry
+      in diagView address id v)
+
+diagView : Signal.Address Action -> Id -> Dash.Diagram.Model -> Html.Html
+diagView address id model = 
   let 
     wrap : Dash.Diagram.Action -> Action
-    wrap = \x -> SubMessage x
+    wrap = \x -> SubMessage id x
   in
     Dash.Diagram.view_histogram (Signal.forwardTo address wrap) model
 

--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -80,11 +80,11 @@ reset_model =
   in Dict.singleton id (Dash.Diagram.init_model id)
 
 -- expects that the key exists. there is no runtime error,
--- but an empty diagram is returned, if the key is not in the model
+-- but an empty diagram with new key is returned, if the key is not in the model
 get_diagram: Id -> Model -> Dash.Diagram.Model
 get_diagram id model = 
   let
-    emptyDiagram = Dash.Diagram.init_model "Unknown Identifier for Chart"
+    emptyDiagram = Dash.Diagram.init_model id -- "Unknown Identifier for Chart"
   in 
     Maybe.withDefault emptyDiagram (Dict.get id model)
 

--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -20,6 +20,7 @@ import Json.Encode exposing (Value)
       ==> DONE
     * design a larger frame, where charts can be embedded. The model is a dictionary,
       mapping ids (or targets) to the diagram model.
+      ==> DONE
     * design an even larger frame with menu etc. 
   What not to do: 
     * Mess around with times etc in Elm since time is bound to signals.

--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -55,7 +55,7 @@ update action model =
 
 
 reset_model : Model
-reset_model = Dash.Diagram.init_model
+reset_model = Dash.Diagram.init_model "elmChart"
 
 -- EFFECTS
 
@@ -108,7 +108,7 @@ diagView address model =
     wrap : Dash.Diagram.Action -> Action
     wrap = \x -> SubMessage x
   in
-    Dash.Diagram.view_histogram "elmChart" (Signal.forwardTo address wrap) model
+    Dash.Diagram.view_histogram (Signal.forwardTo address wrap) model
 
 
 -- WIRING

--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -46,13 +46,20 @@ update : Action -> Model -> (Model, Effects Action)
 update action model = 
     case action of
         NoOp -> (model, Effects.none) -- do nothing
-        Reset -> update_single_diagram NoOp reset_model
+        Reset -> reset_single_diagram reset_model
         SubMessage diag_act -> update_single_diagram diag_act model
           
 update_single_diagram : Dash.Diagram.Action -> Model -> (Model, Effects Action)
 update_single_diagram diag_act model = 
     let
       (m, a) = Dash.Diagram.update (diag_act) model
+    in
+      (m, Effects.map SubMessage a)
+
+reset_single_diagram : Model -> (Model, Effects Action)
+reset_single_diagram model = 
+  let
+      (m, a) = Dash.Diagram.reset model
     in
       (m, Effects.map SubMessage a)
 
@@ -87,7 +94,7 @@ sendValueMailBox : Signal.Mailbox CounterType
 sendValueMailBox =
   let init = { date = 0 * Time.millisecond, value = 0}
   in Signal.mailbox (init) -- initial value!
-    
+
 -- VIEW
 view : Signal.Address Action -> Model -> Html.Html
 view address model =

--- a/web/elm/Dash/Diagram.elm
+++ b/web/elm/Dash/Diagram.elm
@@ -1,4 +1,5 @@
-module Dash.Diagram where
+module Dash.Diagram 
+    (DataPoint, Model, Action, update, init_model, view_histogram, new_value) where
 
 import Time exposing (Time)
 import List exposing (..)
@@ -28,6 +29,9 @@ type alias Simple_Options = {
     , right : Int
     , min_x : Maybe Float
 }
+
+new_value : DataPoint -> Action
+new_value dp = NewValue dp
 
 ----------------------------------------------------------------
 -- Update the model

--- a/web/elm/Dash/Diagram.elm
+++ b/web/elm/Dash/Diagram.elm
@@ -1,5 +1,6 @@
 module Dash.Diagram 
-    (DataPoint, Model, Action, update, init_model, view_histogram, new_value) where
+    (DataPoint, Model, Action, reset, update, init_model, view_histogram, new_value,
+        diagram_stream_mailbox) where
 
 import Time exposing (Time)
 import List exposing (..)
@@ -18,7 +19,7 @@ type alias History = List DataPoint
 
 -- Each diagram has an id (its target) and the history of data points
 type alias Model = {id: Target, history: History}
-type Action = NoOp | NewValue DataPoint
+type Action = NoOp | Reset | NewValue DataPoint
 
 -- options for simple graphs
 type alias Simple_Options = {
@@ -65,6 +66,7 @@ update : Action -> Model -> (Model, Effects Action)
 update action model = 
     case action of
         NoOp -> (model, Effects.none) -- do nothing
+        Reset -> (model, show_diagram model) -- set a (empty?) model and show it
         NewValue value -> let m = set_model value model 
           in (m, show_diagram m) -- receive a new value and store it as model value
 
@@ -77,6 +79,9 @@ set_model data m = Debug.log "set_model: " { m | history = data :: m.history}
 init_model : Target -> Model
 init_model new_id = {id = new_id, history = []}
 
+-- 
+reset : Model -> (Model, Effects Action)
+reset model = update Reset model
 
 ----------------------------------------------------------------
 -- View the histogram

--- a/web/elm/Dash/Diagram.elm
+++ b/web/elm/Dash/Diagram.elm
@@ -2,6 +2,9 @@ module Dash.Diagram where
 
 import Time exposing (Time)
 import List exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (class, id)
+import Effects exposing (Effects, Never)
 
 ----------------------------------------------------------------
 -- TYPES
@@ -10,6 +13,9 @@ import List exposing (..)
 type alias Target = String
 type alias DataPoint = {date: Time, value: Int}
 type alias History = List DataPoint
+
+type alias Model = History
+type Action = NoOp | NewValue DataPoint
 
 -- options for simple graphs
 type alias Simple_Options = {
@@ -21,6 +27,33 @@ type alias Simple_Options = {
     , right : Int
     , min_x : Maybe Float
 }
+
+----------------------------------------------------------------
+-- Update the model
+----------------------------------------------------------------
+update : Action -> Model -> (Model, Effects Action)
+update action model = 
+    case action of
+        NoOp -> (model, Effects.none) -- do nothing
+        NewValue value -> let m = set_model value model 
+          in (m, show_diagram m) -- receive a new value and store it as model value
+
+
+-- puts a new datapoint on top of the list.
+set_model : DataPoint -> Model -> Model
+set_model value xs = Debug.log "set_model: " value :: xs
+
+-- The initial state of the model is the empty list.
+init_model : Model
+init_model = []
+
+
+----------------------------------------------------------------
+-- View the histogram
+----------------------------------------------------------------
+view_histogram : Target -> Signal.Address Action -> Model -> Html.Html 
+view_histogram diagram_id address model = 
+    p [id diagram_id] []
 
 -- simple_histogram
 -- call this function with the Model history and
@@ -45,6 +78,20 @@ min_gt_zero hist =
         |> map (\x -> x.date) 
         |> filter (\x -> x > 0)
         |> minimum
+
+----------------------------------------------------------------
+-- Update the histogram chart with new data 
+----------------------------------------------------------------
+-- send the model to draw a diagram
+show_diagram : Model -> Effects Action
+show_diagram history =
+  let 
+    eff s = s |> Effects.task |> Effects.map (always NoOp)
+    diagram = Debug.log "show_diagram: " (simple_histogram history "#elmChart")
+  in
+    Effects.batch [
+      Signal.send diagram_stream_mailbox.address diagram |> eff 
+    ]
 
 
 -- diagram_stream 

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -24,7 +24,8 @@ import {sample_graph, set_diagram_port} from "./diagram";
 
 // connect with our Elm main module `Elm.Dash`
 var elmDiv = document.getElementById('elm-main')
-	, initialPortState = {getCounterValue: {date: 0, value: 0}}
+	, initialPortState = 
+      {getCounterValue: {id: "unknown", counter: {date: 0, value: 0}}}
     , elmApp = Elm.embed(Elm.Dash, elmDiv, initialPortState);
 
 // join channel and set initial state

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -40,16 +40,14 @@ channel.join()
 
 // elm ports
 // Send a new value to phoenix
+// ==> This is a blue-print for interaction. Will eventually become
+//     an interface to create or subscribe to new counters
 elmApp.ports.sendValuePort.subscribe(value => {
 	console.log("send value to phoenix: ", value);
   channel.push("set_value", value)
          .receive("error", payload => console.log(payload.message))
 });
-// receive a new model history from Elm
-elmApp.ports.sendHistoryPort.subscribe(history => {
-  console.log("got history from Elm: ", history);
-  
-});
+
 // get a counter value and send it to Elm
 channel.on("getCounterValue", counter => {
 	console.log("getCounterValue from Phoenix: ", counter);
@@ -57,5 +55,4 @@ channel.on("getCounterValue", counter => {
 	);
 
 // Graphics
-// sample_graph();
 set_diagram_port(elmApp.ports.data_graph_port);

--- a/web/static/js/diagram.js
+++ b/web/static/js/diagram.js
@@ -10,7 +10,13 @@ function set_diagram_port(port) {
     graph_options.data = d;
     console.log("converted data");
     console.log(graph_options.data);
-    return MG.data_graphic(graph_options);
+    try {
+      return MG.data_graphic(graph_options);
+    } catch (e) {
+      console.warn("Got Exception inside MG.data_graphic");
+      console.warn(e);
+      return true;
+    };
   });
 };
 


### PR DESCRIPTION
Supporting many diagrams required the following changes: 
- a new protocol between Elm and Elixir to identify the counter value with its id
- a new model for Dash: `Dict Id Dash.Diagram.Model` 
- moving all diagram code into `Diagram.elm` such that it becomes independent of the new Dash model.
- new actions on the Dash level, embedding the Diagram actions as sub actions
- new HTML output to allow many diagrams viewed at the same time
