### PR TITLE
No HTML code in the main module

### DIFF
--- a/web/elm/Dash.elm
+++ b/web/elm/Dash.elm
@@ -3,15 +3,16 @@ module Dash where
 import StartApp exposing (App)
 import Effects exposing (Effects, Never)
 import Task exposing (Task)
+import Html exposing (..)
 import Time exposing (Time)
+import Json.Encode as JS -- exposing (Value)
+
 import Dict exposing (Dict)
 
-import Html exposing (..)
-import Html.Attributes exposing (class, id)
-import Html.Events exposing (onClick)
 
 import Dash.Diagram exposing (..)
-import Json.Encode as JS -- exposing (Value)
+import Dash.Board exposing (..)
+
 
 {-- 
   What to do here properly: 
@@ -26,6 +27,7 @@ import Json.Encode as JS -- exposing (Value)
       ==> DONE
     * Refactor Dash.elm such that a library module for handling diagrams exists
       and a main module with ports, signals and wirings to connect to Elixir.
+      ==> DONE
     * design an even larger frame with menu etc. 
   What not to do: 
     * Mess around with times etc in Elm since time is bound to signals.
@@ -33,139 +35,45 @@ import Json.Encode as JS -- exposing (Value)
 
 
 
-init : (Model, Effects Action)
-init =
-  (reset_model, Effects.none)
-
-
--- MODEL
-type alias Id = String 
-type alias Model = Dict.Dict Id Dash.Diagram.Model
-
--- the counter update message as sent from Phoenix
-type alias CounterMsg = {id: Id, counter: CounterType}
--- The counter holds the value and the current time stamp
-type alias CounterType = {date: Time, value: Int}
-type alias History = List CounterType
-
--- UPDATE
-
-type Action 
-  = NoOp 
-  | Reset Id
-  | SubMessage Id Dash.Diagram.Action
-
-update : Action -> Model -> (Model, Effects Action)
-update action model = 
-    case action of
-        NoOp -> (model, Effects.none) -- do nothing
-        Reset id -> reset_single_diagram id reset_model
-        SubMessage id diag_act -> update_single_diagram id diag_act model
-          
-update_single_diagram : Id -> Dash.Diagram.Action -> Model -> (Model, Effects Action)
-update_single_diagram id diag_act model = 
-    let
-      diag = get_diagram id model 
-      (d, a) = Dash.Diagram.update (diag_act) diag
-      m = Dict.update id (\v -> Just d) model
-    in
-      (m, Effects.map (SubMessage id) a)
-
-reset_single_diagram : Id -> Model -> (Model, Effects Action)
-reset_single_diagram id model = 
-  let
-      diag = get_diagram id model
-      (d, a) = Dash.Diagram.reset diag
-      m = Dict.update id (\v -> Just d) model
-    in
-      (m, Effects.map (SubMessage id) a)
-
-reset_model : Model
-reset_model = 
-  let 
-    id = "elmChart" 
-    title = id
-  in Dict.singleton id (Dash.Diagram.init_model id title)
-
--- expects that the key exists. there is no runtime error,
--- but an empty diagram with new key is returned, if the key is not in the model
-get_diagram: Id -> Model -> Dash.Diagram.Model
-get_diagram id model = 
-  let
-    opts = [("y_scale_type", JS.string "linear") ]
-    emptyDiagram = Dash.Diagram.init_model_with_opts id (diagram_title id) opts
-  in 
-    Maybe.withDefault emptyDiagram (Dict.get id model)
-
-diagram_title : Id -> String
-diagram_title id = case id of
-  "first" -> "Diagram No 1: Counter First"
-  "second" -> "Diagram No 2: Counter Second"
-  _ ->  "Unknown Identifier for Chart"
-
 
 -- EFFECTS
 
 -- PORTS
 
 -- Write something towards phoenix
-port sendValuePort : Signal CounterType
+port sendValuePort : Signal Dash.Board.CounterType
 port sendValuePort = 
     sendValueMailBox.signal 
 
 -- Get something from phoenix
-port getCounterValue : Signal CounterMsg
+port getCounterValue : Signal Dash.Board.CounterMsg
 
 -- Output Ports => results in drawing graph of diagram_stream via JS 
 port data_graph_port : Signal JS.Value
 port data_graph_port = diagram_stream_mailbox.signal
 
 -- SIGNALS
-setCounterAction: Signal Action
+setCounterAction: Signal Dash.Board.Action
 setCounterAction = 
-  Signal.map (\v -> 
-      SubMessage v.id (Dash.Diagram.new_value v.counter)) getCounterValue
+  Signal.map Dash.Board.make_counter_action getCounterValue
 
-incomingActions : Signal Action
+incomingActions : Signal Dash.Board.Action
 incomingActions = setCounterAction
 
-sendValueMailBox : Signal.Mailbox CounterType
+sendValueMailBox : Signal.Mailbox Dash.Board.CounterType
 sendValueMailBox =
   let init = { date = 0 * Time.millisecond, value = 0}
   in Signal.mailbox (init) -- initial value!
 
--- VIEW
-view : Signal.Address Action -> Model -> Html.Html
-view address model =
- div []
-    [ h2 [class "chart_title"] [(text "The Big Elm Chart - List Chart variant")]
-    , div [] (all_diags address model)
-    ]
-
-all_diags : Signal.Address Action ->Model -> List Html.Html
-all_diags address model = 
-  Dict.toList model 
-    |> List.map (\entry -> 
-      let (id, v) = entry
-      in diagView address id v)
-
-diagView : Signal.Address Action -> Id -> Dash.Diagram.Model -> Html.Html
-diagView address id model = 
-  let 
-    wrap : Dash.Diagram.Action -> Action
-    wrap = \x -> SubMessage id x
-  in
-    Dash.Diagram.view_histogram (Signal.forwardTo address wrap) model
-
 
 -- WIRING
 
-app : App Model
+app : App Dash.Board.Model
 app =
   StartApp.start
-    { init = init
-    , update = update
-    , view = view
+    { init = Dash.Board.init
+    , update = Dash.Board.update
+    , view = Dash.Board.view
     , inputs = [incomingActions]
     }
 

--- a/web/elm/Dash/Board.elm
+++ b/web/elm/Dash/Board.elm
@@ -1,0 +1,116 @@
+module Dash.Board (view, update, init, make_counter_action,
+    Action, Model, CounterMsg, CounterType) where
+
+import Dict exposing (Dict)
+import Effects exposing (Effects, Never)
+import Html exposing (..)
+import Html.Attributes exposing (class, id)
+import Html.Events exposing (onClick)
+import Time exposing (Time)
+import Json.Encode as JS -- exposing (Value)
+
+import Dash.Diagram exposing (..)
+
+
+----------------------------------------------------------------
+-- MODEL
+----------------------------------------------------------------
+type alias Id = String 
+type alias Model = Dict.Dict Id Dash.Diagram.Model
+
+-- the counter update message as sent from Phoenix
+type alias CounterMsg = {id: Id, counter: CounterType}
+-- The counter holds the value and the current time stamp
+type alias CounterType = {date: Time, value: Int}
+type alias History = List CounterType
+
+init : (Model, Effects Action)
+init =
+  (reset_model, Effects.none)
+
+----------------------------------------------------------------
+-- UPDATE
+----------------------------------------------------------------
+type Action 
+  = NoOp 
+  | Reset Id
+  | SubMessage Id Dash.Diagram.Action
+
+make_counter_action : CounterMsg -> Action
+make_counter_action v = 
+      SubMessage v.id (Dash.Diagram.new_value v.counter)
+
+update : Action -> Model -> (Model, Effects Action)
+update action model = 
+    case action of
+        NoOp -> (model, Effects.none) -- do nothing
+        Reset id -> reset_single_diagram id reset_model
+        SubMessage id diag_act -> update_single_diagram id diag_act model
+          
+update_single_diagram : Id -> Dash.Diagram.Action -> Model -> (Model, Effects Action)
+update_single_diagram id diag_act model = 
+    let
+      diag = get_diagram id model 
+      (d, a) = Dash.Diagram.update (diag_act) diag
+      m = Dict.update id (\v -> Just d) model
+    in
+      (m, Effects.map (SubMessage id) a)
+
+reset_single_diagram : Id -> Model -> (Model, Effects Action)
+reset_single_diagram id model = 
+  let
+      diag = get_diagram id model
+      (d, a) = Dash.Diagram.reset diag
+      m = Dict.update id (\v -> Just d) model
+    in
+      (m, Effects.map (SubMessage id) a)
+
+reset_model : Model
+reset_model = 
+  let 
+    id = "elmChart" 
+    title = id
+  in Dict.singleton id (Dash.Diagram.init_model id title)
+
+-- expects that the key exists. there is no runtime error,
+-- but an empty diagram with new key is returned, if the key is not in the model
+get_diagram: Id -> Model -> Dash.Diagram.Model
+get_diagram id model = 
+  let
+    opts = [("y_scale_type", JS.string "linear") ]
+    emptyDiagram = Dash.Diagram.init_model_with_opts id (diagram_title id) opts
+  in 
+    Maybe.withDefault emptyDiagram (Dict.get id model)
+
+diagram_title : Id -> String
+diagram_title id = case id of
+  "first" -> "Diagram No 1: Counter First"
+  "second" -> "Diagram No 2: Counter Second"
+  _ ->  "Unknown Identifier for Chart"
+----------------------------------------------------------------
+-- VIEW
+----------------------------------------------------------------
+view : Signal.Address Action -> Model -> Html.Html
+view address model =
+ div []
+    [ h2 [class "chart_title"] [(text "The Big Elm Chart - List Chart variant")]
+    , div [] (all_diags address model)
+    ]
+
+all_diags : Signal.Address Action ->Model -> List Html.Html
+all_diags address model = 
+  Dict.toList model 
+    |> List.map (\entry -> 
+      let (id, v) = entry
+      in diagView address id v)
+
+diagView : Signal.Address Action -> Id -> Dash.Diagram.Model -> Html.Html
+diagView address id model = 
+  let 
+    wrap : Dash.Diagram.Action -> Action
+    wrap = \x -> SubMessage id x
+  in
+    Dash.Diagram.view_histogram (Signal.forwardTo address wrap) model
+
+
+


### PR DESCRIPTION
Moved all HTML and drawing code away from the main module (`Dash.elm`). This way, the main module is only concerned with wiring up the application and with the communication towards Javascript and Phoenix. 

The code for managing and showing a set of diagrams, the dash board, is a pure Elm library which is independent of the wiring.
